### PR TITLE
Fix tests with build errors not being reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+* Report build errors
+
 ## 2.13.0 - 2021-11-09
 
 ### Added

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -67,7 +67,8 @@ module.exports = {
       {
         suiteName: `${name} tests`,
         outputDirectory: reportDirectory,
-        outputName: `TEST-${name}.xml`
+        outputName: `TEST-${name}.xml`,
+        reportTestSuiteErrors: true
       }
     ]
   ]


### PR DESCRIPTION
## Proposed changes

If a jest test fails due to build errors, it is not reported at all. This causes broken builds locally not to appear broken/unstable on jenkins. To enable this, a flag has to be set in the jest-junit configuration.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
