### PR TITLE
Add mocks for private modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+* Add mocks for private modules
+
 ## 2.13.0 - 2021-11-09
 
 ### Added

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -53,7 +53,9 @@ module.exports = {
   transformIgnorePatterns: ["node_modules/(?!(@scm-manager)/)"],
   moduleNameMapper: {
     "\\.(png|svg|jpg|gif|woff2?|eot|ttf)$": path.join(mockDirectory, "fileMock.js"),
-    "\\.(css|scss|sass)$": path.join(mockDirectory, "styleMock.js")
+    "\\.(css|scss|sass)$": path.join(mockDirectory, "styleMock.js"),
+    "@scm-manager/ui-text": path.join(mockDirectory, "ui-text.js"),
+    "@scm-manager/ui-syntaxhighlighting": path.join(mockDirectory, "ui-syntaxhighlighting.js")
   },
   setupFiles: [path.resolve(__dirname, "src", "setup.js")],
   collectCoverage: isCI,

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -55,7 +55,8 @@ module.exports = {
     "\\.(png|svg|jpg|gif|woff2?|eot|ttf)$": path.join(mockDirectory, "fileMock.js"),
     "\\.(css|scss|sass)$": path.join(mockDirectory, "styleMock.js"),
     "@scm-manager/ui-text": path.join(mockDirectory, "ui-text.js"),
-    "@scm-manager/ui-syntaxhighlighting": path.join(mockDirectory, "ui-syntaxhighlighting.js")
+    "@scm-manager/ui-syntaxhighlighting": path.join(mockDirectory, "ui-syntaxhighlighting.js"),
+    "@scm-manager/ui-styles": path.join(mockDirectory, "ui-styles.js")
   },
   setupFiles: [path.resolve(__dirname, "src", "setup.js")],
   collectCoverage: isCI,

--- a/src/__mocks__/ui-styles.js
+++ b/src/__mocks__/ui-styles.js
@@ -1,0 +1,25 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+module.exports = {};

--- a/src/__mocks__/ui-syntaxhighlighting.js
+++ b/src/__mocks__/ui-syntaxhighlighting.js
@@ -24,5 +24,5 @@
 
 module.exports = {
   SyntaxHighlighter: () => null,
-  useSyntaxHighlightingWorker: () => new Worker("foo.bar", undefined)
+  useSyntaxHighlightingWorker: () => ({})
 };

--- a/src/__mocks__/ui-syntaxhighlighting.js
+++ b/src/__mocks__/ui-syntaxhighlighting.js
@@ -1,0 +1,28 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+module.exports = {
+  SyntaxHighlighter: () => null,
+  useSyntaxHighlightingWorker: () => new Worker("foo.bar", undefined)
+};

--- a/src/__mocks__/ui-text.js
+++ b/src/__mocks__/ui-text.js
@@ -1,0 +1,28 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+module.exports = {
+  SplitAndReplace: () => null,
+  Replacement: () => null
+};


### PR DESCRIPTION
## Proposed changes

Recently, we split some of the code off from `ui-components` to their own, private modules. This works fine for the production build and type-checking, but fails when jest tries to resolve them as they are not published to npm. We fix this by adding mocks for the private modules which allows jest to resolve them and execute tests properly.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
